### PR TITLE
Support for child waitgroup; Refactored test with tokio::test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ readme = "README.md"
 [dependencies]
 
 [dev-dependencies]
-tokio = { version = "1", features = ["rt", "time"] }
+tokio = { version = "1", features = [ "rt", "rt-multi-thread", "macros", "time"]}


### PR DESCRIPTION
What a good waitgroup implementation in rust!
This PR does two things:
1. Support for child `WaitGroup`.
    Child `WaitGroup` can derive `Worker`s and `wait` for all `Workers` finish executing like a normal `WaitGroup`. Parent `WaitGroup` will stop waiting only after the workers registered in it and its child `WaitGroup`s finish executing, but the child `WaitGroup` will stop waiting after its registered workers finish executing, regardless of the workers in parent. 

2. Refactored test with tokio::test
   In current tests, the runtime is built manually. Tokio provides macro `tokio::test` to run a async test, and i used this macro to refactor all tests. Moreover, current tests only test whether the `WaitGroup` can stop waiting or not, but whether the `WaitGroup` stops waiting after the all worker tasks finish is not tested. Time asserts were added to test where `WaitGroup` stops waiting after the most time-consuming task finish. The test for child `WaitGroup` were also added.  