### PR TITLE
use AtomicWaker instead of Mutex<Option<Waker>>

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,8 @@ categories = ["asynchronous", "concurrency"]
 readme = "README.md"
 
 [dependencies]
-futures = "0.3"
+atomic-waker = "1.0.0"
+
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "time"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["asynchronous", "concurrency"]
 readme = "README.md"
 
 [dependencies]
+futures = "0.3"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "time"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,8 +72,10 @@ use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
-use std::task::{Context, Poll, Waker};
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use futures::task::AtomicWaker;
 
 /// Wait for a collection of tasks to finish execution.
 ///
@@ -124,8 +126,7 @@ impl Future for WaitGroupFuture<'_> {
     type Output = ();
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let waker = cx.waker().clone();
-        *self.inner.waker.lock().unwrap() = Some(waker);
+        self.inner.waker.register(cx.waker());
 
         match self.inner.count.load(Ordering::Relaxed) {
             0 => Poll::Ready(()),
@@ -135,7 +136,7 @@ impl Future for WaitGroupFuture<'_> {
 }
 
 struct Inner {
-    waker: Mutex<Option<Waker>>,
+    waker: AtomicWaker,
     count: AtomicUsize,
 }
 
@@ -143,7 +144,7 @@ impl Inner {
     pub fn new() -> Self {
         Self {
             count: AtomicUsize::new(0),
-            waker: Mutex::new(None),
+            waker: AtomicWaker::new(),
         }
     }
 }
@@ -178,7 +179,7 @@ impl Drop for Worker {
         let count = self.inner.count.fetch_sub(1, Ordering::Relaxed);
         // We are the last worker
         if count == 1 {
-            if let Some(waker) = self.inner.waker.lock().unwrap().take() {
+            if let Some(waker) = self.inner.waker.take() {
                 waker.wake();
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use futures::task::AtomicWaker;
+use atomic_waker::AtomicWaker;
 
 /// Wait for a collection of tasks to finish execution.
 ///


### PR DESCRIPTION
`futures` crate provides a useful synchronization primitive `AtomicWaker`. I think it is a better choice over `Mutex<Option<Waker>>`.