### PR TITLE
Revert to locked waker

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,6 @@ categories = ["asynchronous", "concurrency"]
 readme = "README.md"
 
 [dependencies]
-atomic-waker = "1.0.0"
-
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "time"] }


### PR DESCRIPTION
Reverts #2.

The `Mutex<Option<Waker>>` is only accessed by `poll` and the last worker, so it is realistically always uncontended. The cost of locking an uncontended `Mutex` should actually be _cheaper_ than `wake` on `AtomicWaker`, but either way this avoids the extra dependency and shouldn't have any significant performance implications.