### PR TITLE
Remove unnecessary 'mut'

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ impl WaitGroup {
     }
 
     /// Wait until all registered workers finish executing.
-    pub async fn wait(&mut self) {
+    pub async fn wait(&self) {
         WaitGroupFuture::new(&self.inner).await
     }
 }
@@ -215,7 +215,7 @@ mod tests {
             .unwrap();
 
         rt.block_on(async {
-            let mut wg = WaitGroup::new();
+            let wg = WaitGroup::new();
 
             for _ in 0..5 {
                 let worker = wg.worker();
@@ -237,7 +237,7 @@ mod tests {
             .unwrap();
 
         rt.block_on(async {
-            let mut wg = WaitGroup::new();
+            let wg = WaitGroup::new();
 
             for _ in 0..5 {
                 let worker = wg.worker();
@@ -268,7 +268,7 @@ mod tests {
             .unwrap();
 
         rt.block_on(async {
-            let mut wg = WaitGroup::new();
+            let wg = WaitGroup::new();
 
             for _ in 0..5 {
                 let worker = wg.worker();


### PR DESCRIPTION
There is no need for the `mut` keyword in `WaitGroup::wait`.  The library builds and passes tests without it.